### PR TITLE
Тесты AuthController, коррект. login в AuthServiceImpl

### DIFF
--- a/src/main/java/ru/skypro/homework/dto/LoginReqDto.java
+++ b/src/main/java/ru/skypro/homework/dto/LoginReqDto.java
@@ -3,7 +3,6 @@ package ru.skypro.homework.dto;
 import lombok.*;
 
 @Data
-@AllArgsConstructor
 public class LoginReqDto {
     private String username;
     private String password;

--- a/src/main/java/ru/skypro/homework/dto/LoginReqDto.java
+++ b/src/main/java/ru/skypro/homework/dto/LoginReqDto.java
@@ -3,7 +3,8 @@ package ru.skypro.homework.dto;
 import lombok.*;
 
 @Data
+@AllArgsConstructor
 public class LoginReqDto {
-    private String password;
     private String username;
+    private String password;
 }

--- a/src/main/java/ru/skypro/homework/dto/RegisterReqDto.java
+++ b/src/main/java/ru/skypro/homework/dto/RegisterReqDto.java
@@ -3,7 +3,6 @@ package ru.skypro.homework.dto;
 import lombok.*;
 
 @Data
-@AllArgsConstructor
 public class RegisterReqDto {
     private String username;
     private String password;

--- a/src/main/java/ru/skypro/homework/dto/RegisterReqDto.java
+++ b/src/main/java/ru/skypro/homework/dto/RegisterReqDto.java
@@ -3,6 +3,7 @@ package ru.skypro.homework.dto;
 import lombok.*;
 
 @Data
+@AllArgsConstructor
 public class RegisterReqDto {
     private String username;
     private String password;

--- a/src/main/java/ru/skypro/homework/service/impl/AuthServiceImpl.java
+++ b/src/main/java/ru/skypro/homework/service/impl/AuthServiceImpl.java
@@ -35,11 +35,14 @@ public class AuthServiceImpl implements AuthService {
         try {
             UserDetails userDetails = userDetailsServiceImpl.loadUserByUsername(userName);
             String encryptedPassword = userDetails.getPassword();
-            return encoder.matches(password, encryptedPassword);
+            if (!encoder.matches(password, encryptedPassword)) {
+                throw new BadCredentialsException("Wrong password!");
+            }
+            return true;
         } catch (UsernameNotFoundException e) {
             throw new BadCredentialsException(String.format("User \"%s\" does not exist!", userName));
         } catch (IllegalArgumentException e) {
-            throw new BadCredentialsException("Wrong password!");
+            throw new BadCredentialsException("Bad credentials!");
         }
     }
 

--- a/src/test/java/ru/skypro/homework/controller/AuthControllerTest.java
+++ b/src/test/java/ru/skypro/homework/controller/AuthControllerTest.java
@@ -16,7 +16,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.transaction.annotation.Transactional;
 import ru.skypro.homework.dto.LoginReqDto;
 import ru.skypro.homework.dto.RegisterReqDto;
 import ru.skypro.homework.dto.Role;
@@ -31,7 +30,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 @AutoConfigureMockMvc
-@Transactional
 public class AuthControllerTest {
 
     @Autowired
@@ -78,8 +76,10 @@ public class AuthControllerTest {
     @Test
     public void testAuthenticateUser() throws Exception {
         User user = getMockUser();
-        LoginReqDto loginReq = new LoginReqDto(user.getEmail(), user.getPassword());
-        String json = mapper.writeValueAsString(loginReq);
+        LoginReqDto req = new LoginReqDto();
+        req.setUsername(user.getEmail());
+        req.setPassword(user.getPassword());
+        String json = mapper.writeValueAsString(req);
         mockMvc.perform(post("/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .characterEncoding("utf-8")
@@ -92,8 +92,10 @@ public class AuthControllerTest {
     public void testAuthenticateUserAdmin() throws Exception {
         User user = getMockUser();
         user.setRole(Role.ADMIN);
-        LoginReqDto loginReq = new LoginReqDto(user.getEmail(), user.getPassword());
-        String json = mapper.writeValueAsString(loginReq);
+        LoginReqDto req = new LoginReqDto();
+        req.setUsername(user.getEmail());
+        req.setPassword(user.getPassword());
+        String json = mapper.writeValueAsString(req);
         mockMvc.perform(post("/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .characterEncoding("utf-8")
@@ -105,8 +107,10 @@ public class AuthControllerTest {
     public void testAuthenticateUserWrongPassword() throws Exception {
         User user = getMockUser();
         Mockito.when(passwordEncoder.matches(Mockito.anyString(), Mockito.anyString())).thenReturn(false);
-        LoginReqDto loginReq = new LoginReqDto(user.getEmail(), user.getPassword());
-        String json = mapper.writeValueAsString(loginReq);
+        LoginReqDto req = new LoginReqDto();
+        req.setUsername(user.getEmail());
+        req.setPassword(user.getPassword());
+        String json = mapper.writeValueAsString(req);
         mockMvc.perform(post("/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .characterEncoding("utf-8")
@@ -117,14 +121,14 @@ public class AuthControllerTest {
     @Test
     public void testRegisterUser() throws Exception {
         User user = getMockUser();
-        RegisterReqDto registerReq = new RegisterReqDto(
-                user.getEmail(),
-                user.getPassword(),
-                user.getFirstName(),
-                user.getLastName(),
-                user.getPhone(),
-                null);
-        String json = mapper.writeValueAsString(registerReq);
+        RegisterReqDto req = new RegisterReqDto();
+        req.setUsername(user.getEmail());
+        req.setPassword(user.getPassword());
+        req.setFirstName(user.getFirstName());
+        req.setLastName(user.getLastName());
+        req.setPhone(user.getPhone());
+        req.setRole(null);
+        String json = mapper.writeValueAsString(req);
         mockMvc.perform(post("/register")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(json))

--- a/src/test/java/ru/skypro/homework/controller/AuthControllerTest.java
+++ b/src/test/java/ru/skypro/homework/controller/AuthControllerTest.java
@@ -1,0 +1,133 @@
+package ru.skypro.homework.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+import ru.skypro.homework.dto.LoginReqDto;
+import ru.skypro.homework.dto.RegisterReqDto;
+import ru.skypro.homework.dto.Role;
+import ru.skypro.homework.entity.User;
+import ru.skypro.homework.security.MyUserDetails;
+import ru.skypro.homework.security.UserDetailsServiceImpl;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+@Transactional
+public class AuthControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    AuthController authController;
+
+    @MockBean
+    private UserDetailsServiceImpl userDetailsService;
+
+    @MockBean
+    private PasswordEncoder passwordEncoder;
+
+    private static ObjectMapper mapper = new ObjectMapper();
+
+
+    @Test
+    void contextLoads() {
+        Assertions.assertThat(authController).isNotNull();
+    }
+
+    private static User getMockUser() {
+        User user = new User();
+        user.setId(1L);
+        user.setEmail("test@mail.com");
+        user.setPassword("password");
+        user.setFirstName("FirstName");
+        user.setLastName("LastName");
+        user.setPhone("+70000000000");
+        user.setRole(Role.USER);
+        return user;
+    }
+
+    @BeforeEach
+    public void init() {
+        User user = getMockUser();
+        Authentication auth = new UsernamePasswordAuthenticationToken(getMockUser(), "password");
+        SecurityContextHolder.getContext().setAuthentication(auth);
+        Mockito.when(userDetailsService.loadUserByUsername(Mockito.anyString())).thenReturn(new MyUserDetails(user));
+        Mockito.when(passwordEncoder.matches(Mockito.anyString(), Mockito.anyString())).thenReturn(true);
+    }
+
+    @Test
+    public void testAuthenticateUser() throws Exception {
+        User user = getMockUser();
+        LoginReqDto loginReq = new LoginReqDto(user.getEmail(), user.getPassword());
+        String json = mapper.writeValueAsString(loginReq);
+        mockMvc.perform(post("/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(json)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void testAuthenticateUserAdmin() throws Exception {
+        User user = getMockUser();
+        user.setRole(Role.ADMIN);
+        LoginReqDto loginReq = new LoginReqDto(user.getEmail(), user.getPassword());
+        String json = mapper.writeValueAsString(loginReq);
+        mockMvc.perform(post("/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(json))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void testAuthenticateUserWrongPassword() throws Exception {
+        User user = getMockUser();
+        Mockito.when(passwordEncoder.matches(Mockito.anyString(), Mockito.anyString())).thenReturn(false);
+        LoginReqDto loginReq = new LoginReqDto(user.getEmail(), user.getPassword());
+        String json = mapper.writeValueAsString(loginReq);
+        mockMvc.perform(post("/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(json))
+                .andExpect(status().is(403));
+    }
+
+    @Test
+    public void testRegisterUser() throws Exception {
+        User user = getMockUser();
+        RegisterReqDto registerReq = new RegisterReqDto(
+                user.getEmail(),
+                user.getPassword(),
+                user.getFirstName(),
+                user.getLastName(),
+                user.getPhone(),
+                null);
+        String json = mapper.writeValueAsString(registerReq);
+        mockMvc.perform(post("/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/ru/skypro/homework/controller/AuthControllerTest.java
+++ b/src/test/java/ru/skypro/homework/controller/AuthControllerTest.java
@@ -10,6 +10,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -22,7 +23,9 @@ import ru.skypro.homework.dto.Role;
 import ru.skypro.homework.entity.User;
 import ru.skypro.homework.security.MyUserDetails;
 import ru.skypro.homework.security.UserDetailsServiceImpl;
+import ru.skypro.homework.service.AuthService;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -38,6 +41,9 @@ public class AuthControllerTest {
     @Autowired
     AuthController authController;
 
+    @Autowired
+    AuthService authService;
+
     @MockBean
     private UserDetailsServiceImpl userDetailsService;
 
@@ -52,7 +58,7 @@ public class AuthControllerTest {
         Assertions.assertThat(authController).isNotNull();
     }
 
-    private static User getMockUser() {
+    public static User getMockUser() {
         User user = new User();
         user.setId(1L);
         user.setEmail("test@mail.com");
@@ -116,6 +122,8 @@ public class AuthControllerTest {
                         .characterEncoding("utf-8")
                         .content(json))
                 .andExpect(status().is(403));
+        assertThrows(BadCredentialsException.class,
+                () -> authService.login(req.getUsername(), req.getPassword()), "Wrong password!");
     }
 
     @Test

--- a/src/test/java/ru/skypro/homework/controller/AuthControllerThrowTest.java
+++ b/src/test/java/ru/skypro/homework/controller/AuthControllerThrowTest.java
@@ -1,0 +1,88 @@
+package ru.skypro.homework.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+import ru.skypro.homework.dto.LoginReqDto;
+import ru.skypro.homework.dto.RegisterReqDto;
+import ru.skypro.homework.dto.Role;
+import ru.skypro.homework.entity.User;
+import ru.skypro.homework.repository.UserRepository;
+import ru.skypro.homework.service.AuthService;
+
+import javax.validation.ValidationException;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static ru.skypro.homework.controller.AuthControllerTest.getMockUser;
+
+
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+public class AuthControllerThrowTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    UserDetailsService userDetailsService;
+
+    @Autowired
+    AuthService authService;
+
+    @MockBean
+    private UserRepository userRepository;
+
+    private static ObjectMapper mapper = new ObjectMapper();
+
+
+    @Test
+    public void testAuthenticateUserDoesNotExistThrow() throws Exception {
+        User user = getMockUser();
+        LoginReqDto req = new LoginReqDto();
+        req.setUsername(user.getEmail());
+        req.setPassword(user.getPassword());
+        String json = mapper.writeValueAsString(req);
+        mockMvc.perform(post("/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(json))
+                .andExpect(status().is(403));
+        assertThrows(UsernameNotFoundException.class,
+                () -> userDetailsService.loadUserByUsername(req.getUsername()),
+                "User test@mail.com does not exist!");
+    }
+
+    @Test
+    public void testRegisterUserIsAlreadyRegisteredThrow() throws Exception {
+        Mockito.when(userRepository.existsByEmailIgnoreCase(Mockito.anyString())).thenReturn(true);
+        User user = getMockUser();
+        RegisterReqDto req = new RegisterReqDto();
+        req.setUsername(user.getEmail());
+        req.setPassword(user.getPassword());
+        req.setFirstName(user.getFirstName());
+        req.setLastName(user.getLastName());
+        req.setPhone(user.getPhone());
+        req.setRole(null);
+        String json = mapper.writeValueAsString(req);
+        mockMvc.perform(post("/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(json))
+                .andExpect(status().is(400));
+        assertThrows(ValidationException.class,
+                () -> authService.register(req, Role.USER),
+                "User test@mail.com is already registered!");
+    }
+}


### PR DESCRIPTION
Выполнено:
1. Тесты AuthController без исключений.
Тесты исключений возможно будут тестироваться в другом классе, так как мок-бины не дают зайти внутрь методов сервисов, где выбрасываются исключения.
2. Сначала добавил аннотацию @AllArgsConstructor в LoginReqDto и RegisterRegDto, потом удалил и в тестах использовал их конструкторы без аргументов.
3. Корректировка метода login в AuthServiceImpl - для исключение "Wrong password!" сделал отдельную проверку в if() в блоке try, так как неправильный пароль не вызывал исключение llegalArgumentException как предполагалось.
Также здесь добавил - что при выбрасывании исключения llegalArgumentException создается исключение BadCredentialsException с сообщением "Bad credentials!".
4. Тест testAuthenticateUserAdmin() наверное лишний, но не стал удалять.
5. Добавил тесты исключений в отдельном классе AuthControllerThrowTest.